### PR TITLE
Update alerts.py remove deprecated providing_args

### DIFF
--- a/nextcloud/models/alerts.py
+++ b/nextcloud/models/alerts.py
@@ -4,9 +4,9 @@ from django.dispatch import Signal
 
 logger = logging.getLogger(__name__)
 
-new_membership = Signal(providing_args=["user"])
-ending_membership = Signal(providing_args=["user"])
-changing_membership_password = Signal(providing_args=["user", "password"])
+new_membership = Signal(Signal("user"))
+ending_membership = Signal(Signal("user"))
+changing_membership_password = Signal(["user", "password"])
 
 
 class MemberAlertManager:


### PR DESCRIPTION
providing_args is deprecated in Django 3.1 and removed with Django 4.0